### PR TITLE
feat: add macOS and Windows platform support

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -12,7 +12,9 @@ environment:
 platforms:
   android:
   ios:
+  macos:
   web:
+  windows:
 
 dependencies:
   passkeys: ^2.9.0


### PR DESCRIPTION
Adds macOS and Windows to the supported platforms list.

The `passkeys` dependency already provides full support for these platforms via:
- `passkeys_darwin` (macOS - shared Swift code with iOS)
- `passkeys_windows` (Windows Hello + WebAuthn API)

This change simply declares the platforms in pubspec.yaml to unlock desktop support.

## Changes

- Added `macos:` to platforms in pubspec.yaml
- Added `windows:` to platforms in pubspec.yaml

## Testing

- All existing tests pass (`flutter test` - 34 tests)
- `flutter analyze` passes with no issues