### PR TITLE
fix(passkey): align WebAuthn signature with viem/ox for on-chain verification

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -191,7 +191,32 @@ this is achieved using the tempo transaction format:
 - this creates compatibility with the tempo transaction format, whilst being negliglible for every other evm.
 if the format of the address is not okay, get the key `signer.publicKey` and use it to your taste.
 
-### 5. Interface Changes
+### 5. WebAuthn Signature Metadata
+
+#### `typePos` → `getTypeLocation()`
+
+**Before (v0.x)**
+```dart
+final PassKeySignature sig = await signer.signToPasskeySignature(hash);
+final typePos = sig.typePos; // Returns position of 'webauthn.get' VALUE (index 9)
+```
+
+**After (v1.0.0)**
+```dart
+final Signature sig = await signer.signAsync(hash);
+final typeIndex = sig.getTypeLocation(); // Returns position of '"type"' KEY (index 1)
+```
+
+> [!IMPORTANT]
+> This change aligns with [viem/ox](https://github.com/wevm/ox) behavior. The Kernel WebAuthn validator and other on-chain verifiers expect `typeIndex` to point to the `"type"` field **key** in `clientDataJSON`, not the value.
+>
+> ```
+> clientDataJSON: {"type":"webauthn.get","challenge":"..."}
+>                  ↑
+>                  typeIndex = 1 (position of opening quote)
+> ```
+
+### 6. Interface Changes
 
 The core interface has been renamed to reflect the package's purpose.
 

--- a/lib/src/core/ec_api.dart
+++ b/lib/src/core/ec_api.dart
@@ -55,7 +55,9 @@ final class Signature extends EIP7702MsgSignature implements ECSignature {
   }
 
   int? getTypeLocation() {
-    return clientDataJson?.indexOf('webauthn.get');
+    // Return position of '"type"' key, not 'webauthn.get' value.
+    // The Kernel WebAuthn validator expects the index of the type field.
+    return clientDataJson?.indexOf('"type"');
   }
 
   @override

--- a/lib/src/signing/passkey_signer.dart
+++ b/lib/src/signing/passkey_signer.dart
@@ -85,14 +85,18 @@ final class PassKeySigner implements Signer {
     final sig = getMessagingSignature(b64d(assertion.signature));
 
     final clientDataJSON = utf8.decode(b64d(assertion.clientDataJSON));
+    final curve = SigningCurve.r1;
 
-    return Signature(
+    final ecSig = Signature(
       sig.r.value,
       sig.s.value,
       authData: b64d(assertion.authenticatorData),
       clientDataJson: clientDataJSON,
-      curve: SigningCurve.r1,
+      curve: curve,
     );
+
+    // Normalize S to LOW-S form for on-chain verification (required by P256).
+    return ecSig.normalize(curve.curveParams);
   }
 
   @Deprecated("use signAsync")


### PR DESCRIPTION
- Fix getTypeLocation() to return position of '"type"' key (index 1) instead of 'webauthn.get' value (index 9), matching viem/ox behavior
- Normalize P256 signatures to LOW-S form required for on-chain verification by Kernel and other WebAuthn validators

The typeIndex fix is critical for ERC-4337 smart accounts using WebAuthn/Passkeys with Kernel v0.3.x validators. The validator expects typeIndex to point to the field key, not the value.